### PR TITLE
Solve issues when inserting NA values

### DIFF
--- a/Parser.R
+++ b/Parser.R
@@ -348,8 +348,8 @@ Parser <- R6Class(
             # Group 2: UB, ZB, ZF, ZN, ZT have minimum tick size 1/32 or 1/64 (For example 157'27 = 157.84375, 157'20 = 157.625, ...)
             G1Id <- which(as.matrix(currentProdMap[,2]) %in% c("KE","ZC","ZO","ZS","ZW"))
             G2Id <- which(as.matrix(currentProdMap[,2]) %in% c("UB","ZB","ZF","ZN","ZT"))
-            G1 <- matrix(unlist(lapply(OHLCV[G1Id,c(1:5)], private$frac2float, 1)), ncol = 5)
-            G2 <- matrix(unlist(lapply(OHLCV[G2Id,c(1:5)], private$frac2float, 2)), ncol = 5)
+            G1 <- matrix(unlist(apply(OHLCV[G1Id,c(1:5)], MARGIN = 2, FUN = private$frac2float, group = 1)), ncol = 5)
+            G2 <- matrix(unlist(apply(OHLCV[G2Id,c(1:5)], MARGIN = 2, FUN = private$frac2float, group = 2)), ncol = 5)
             # return(list(G1Id = G1Id, G2Id = G2Id, G1 = G1, G2 = G2, OHLCV = OHLCV)) debug
             OHLCV[G1Id,1:5] <- G1
             OHLCV[G2Id,1:5] <- G2

--- a/Parser.R
+++ b/Parser.R
@@ -98,6 +98,7 @@ Parser <- R6Class(
             # Query construction
             q1 <- apply(private$queryRows, 1, paste, collapse = ", ")
             q2 <- gsub("^(.*)$", "(\\1),", q1)
+            q2 <- gsub("\\bNA\\b", "null", q2)
             q2[[length(q2)]] <- sub(",$",";",q2[[length(q2)]])
             q2 <- c("INSERT INTO daily_price(data_vendor_name,exchange_symbol,vendor_symbol,
                     complete_symbol,contract_month,price_date,open_price,high_price,low_price,


### PR DESCRIPTION
### Issues

When some settlement values are NA, private$frac2float() runs into some issues here:
https://github.com/MMquant/CME_Parser/blob/master/Parser.R#L396
https://github.com/MMquant/CME_Parser/blob/master/Parser.R#L404

Additionally, attempts to insert NA values as double precision are unsuccessful. These cases must be changed to null.

### Changes

To solve the issues with private$frac2float(), an apply call is used instead.
To solve the issues with double precision, NA values are changed to null via regex substitution.
